### PR TITLE
Use TF Encrypted 0.6.0 RC

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tf_encrypted==0.5.9
+tf_encrypted >=0.6.0-rc0, <=0.6.0-rc5
 syft==0.1.29a1
 jupyter==1.0.0


### PR DESCRIPTION
Fixes the requirements, leaving room for a few RC updates before tutorial.

Merge this once we are sure tutorials run on the RC, updating the minimum TFE version as needed.